### PR TITLE
Read SECRET_TOKEN from environment variable

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-LoveTax3::Application.config.secret_token = 'cae1ad4195fab5486dfd2f61477e432bb717aba268af0d7cc05bae191c12d571515c503c5bae1b7e33b6a4e83693d8c0339e81ad0fb09bbcd73e1337f7eb4850'
+LoveTax3::Application.config.secret_token = (Rails.env.development? || Rails.env.test?) ? "insecure_token_just_for_test_and_dev" : ENV.fetch('SECRET_TOKEN')


### PR DESCRIPTION
The Rails secret token should not be committed to source control. Move it to an environment variable and make it clear that the token in dev/test is dummy data.

Thanks to Sander Bos for reporting this.